### PR TITLE
PEP-518 build specification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,7 @@ install:
 - sudo apt update
 - sudo apt install libboost-dev
 - pip install -r requirements.txt
-- python setup.py install
-- pip install pytest
-- pip install coveralls
-- pip install pytest-cov
+- pip install .
 
 script:
 - pytest --cov-append --cov=./waterz ./tests --verbose

--- a/README.md
+++ b/README.md
@@ -16,19 +16,21 @@ Based on the watershed implementation of [Aleksandar Zlateski](https://bitbucket
 # Installation
 
 Install c++ dependencies:
+
 ```
 sudo apt install libboost-dev
 ```
 
-Install from pipy
+Install from PyPI
+
 ```
 pip install waterz
 ```
 
-install manually
+install from local version
+
 ```
-pip install -r requirements.txt
-python setup.py install
+pip install .
 ```
 
 # Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
-requires = ["setuptools", "cython", "numpy", "wheel"]
+requires = ["setuptools", "numpy", "wheel"]
+build-system = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "cython", "numpy", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 requires = ["setuptools", "numpy", "wheel"]
-build-system = "setuptools.build_meta"
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,8 @@
 numpy
 cython
+
+# dev
+
+pytest
+coveralls
+pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,6 @@ VERSION = '0.9.5'
 
 PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
 
-with open(os.path.join(PACKAGE_DIR, "requirements.txt")) as f:
-    requirements = f.read().splitlines()
-    requirements = [l for l in requirements if not l.startswith('#')]
-
 
 with open(os.path.join(PACKAGE_DIR, "README.md"), "r") as fh:
     long_description = fh.read()
@@ -60,7 +56,7 @@ setup(
     license='MIT',
     cmdclass={'build_ext': build_ext},
     setup_requires=['numpy'],
-    install_requires=requirements,
+    install_requires=['numpy', 'cython'],
     tests_require=['pytest'],
     packages=find_packages(),
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools.extension import Extension
 from setuptools.command.build_ext import build_ext as _build_ext
 # from Cython.Build import cythonize
 import os
+import builtins
 
 VERSION = '0.9.5'
 
@@ -24,7 +25,7 @@ class build_ext(_build_ext):
     def finalize_options(self):
         _build_ext.finalize_options(self)
         # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
+        builtins.__NUMPY_SETUP__ = False
         import numpy
         self.include_dirs.append(numpy.get_include())
 

--- a/setup.py
+++ b/setup.py
@@ -70,5 +70,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-    ]
+    ],
+    requires_python=">=3.6, <4",
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import sys
+from pathlib import Path
+
+# waterz is not locally importable;
+# this snippet forces the tests to use the installed version.
+# See here for more details:
+# https://stackoverflow.com/questions/67176036/how-to-prevent-pytest-using-local-module
+project_dir = str(Path(__file__).resolve().parent.parent)
+sys.path = [p for p in sys.path if not p.startswith(project_dir)]


### PR DESCRIPTION
This allows building locally without pre-installing numpy. Contains a few other minor changes.